### PR TITLE
modularize subgoals

### DIFF
--- a/hiro/hiro_utils.py
+++ b/hiro/hiro_utils.py
@@ -119,7 +119,6 @@ class SubgoalActionSpace(object):
             self.high = -self.low
 
     def sample(self):
-        np.random.uniform(low = self.low, high = self.high)
         return (self.high - self.low) * np.random.sample(self.high.shape) + self.low
 
 class Subgoal(object):

--- a/hiro/hiro_utils.py
+++ b/hiro/hiro_utils.py
@@ -107,14 +107,19 @@ class HighReplayBuffer(ReplayBuffer):
         )
 
 class SubgoalActionSpace(object):
-    def __init__(self, dim):
-        limits = np.array([-10, -10, -0.5, -1, -1, -1, -1,
-                    -0.5, -0.3, -0.5, -0.3, -0.5, -0.3, -0.5, -0.3])
-        self.shape = (dim,1)
-        self.low = limits[:dim]
-        self.high = -self.low
+    def __init__(self, dim, limits=np.array([-10, -10, -0.5, -1, -1, -1, -1,
+                 -0.5, -0.3, -0.5, -0.3, -0.5, -0.3, -0.5, -0.3]),
+                 low=None, high=None):
+
+        if low is not None and high is not None:
+            self.shape = (dim,1)
+        else:
+            self.shape = (dim,1)
+            self.low = limits[:dim]
+            self.high = -self.low
 
     def sample(self):
+        np.random.uniform(low = self.low, high = self.high)
         return (self.high - self.low) * np.random.sample(self.high.shape) + self.low
 
 class Subgoal(object):


### PR DESCRIPTION
This PR allows for developers to define the limits or high/low values for the subgoal space. Before, these limits were hard-coded for the ant environments.